### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/src/Cake.ProjHelpers/Cake.ProjHelpers/Cake.ProjHelpers.csproj
+++ b/src/Cake.ProjHelpers/Cake.ProjHelpers/Cake.ProjHelpers.csproj
@@ -35,8 +35,8 @@
     <DocumentationFile>bin\Release\Cake.ProjHelpers.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.15.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.15.2\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Cake.ProjHelpers/Cake.ProjHelpers/packages.config
+++ b/src/Cake.ProjHelpers/Cake.ProjHelpers/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.15.2" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.